### PR TITLE
dont trigger redraw

### DIFF
--- a/uderzo/lib/uderzo/gen_renderer.ex
+++ b/uderzo/lib/uderzo/gen_renderer.ex
@@ -126,10 +126,9 @@ defmodule Uderzo.GenRenderer do
     {:reply, state.user_state, state}
   end
 
-  # Set the user state directly and trigger a screen redraw.
+  # Set the user state directly.
   def handle_call({:set_user_state, new_state}, _from, state) do
     state = %State{state | user_state: new_state}
-    send(self(), :render_next)
     {:reply, state, state}
   end
 


### PR DESCRIPTION
sending the :render_next message will actually trigger another redrawing loop and can overload weaker processors. The simplest spultion is to just change the state and let the normal redraw cycle update the screen.
Sorry for the confusion with the earlier PR.